### PR TITLE
[IPM] Fixed broken IPM communiation due the unified kernel API change

### DIFF
--- a/src/zjs_aio.c
+++ b/src/zjs_aio.c
@@ -79,7 +79,7 @@ static bool zjs_aio_ipm_send_sync(zjs_ipm_message_t* send,
     // block until reply or timeout, we shouldn't see the ARC
     // time out, if the ARC response comes back after it
     // times out, it could pollute the result on the stack
-    if (!k_sem_take(&aio_sem, ZJS_AIO_TIMEOUT_TICKS)) {
+    if (k_sem_take(&aio_sem, ZJS_AIO_TIMEOUT_TICKS)) {
         ERR_PRINT("zjs_aio_ipm_send_sync: FATAL ERROR, ipm timed out\n");
         return false;
     }

--- a/src/zjs_ble.c
+++ b/src/zjs_ble.c
@@ -244,7 +244,7 @@ static ssize_t zjs_ble_read_attr_callback(struct bt_conn *conn,
         zjs_signal_callback(chrc->read_cb.id, NULL, 0);
 
         // block until result is ready
-        if (!k_sem_take(&ble_sem, ZJS_BLE_TIMEOUT_TICKS)) {
+        if (k_sem_take(&ble_sem, ZJS_BLE_TIMEOUT_TICKS)) {
             ERR_PRINT("zjs_ble_read_attr_callback: JS callback timed out\n");
             return BT_GATT_ERR(BT_ATT_ERR_UNLIKELY);
         }
@@ -360,7 +360,7 @@ static ssize_t zjs_ble_write_attr_callback(struct bt_conn *conn,
         zjs_signal_callback(chrc->write_cb.id, NULL, 0);
 
         // block until result is ready
-        if (!k_sem_take(&ble_sem, ZJS_BLE_TIMEOUT_TICKS)) {
+        if (k_sem_take(&ble_sem, ZJS_BLE_TIMEOUT_TICKS)) {
             ERR_PRINT("zjs_ble_write_attr_callback: JS callback timed out\n");
             return BT_GATT_ERR(BT_ATT_ERR_UNLIKELY);
         }

--- a/src/zjs_grove_lcd.c
+++ b/src/zjs_grove_lcd.c
@@ -34,7 +34,7 @@ static bool zjs_glcd_ipm_send_sync(zjs_ipm_message_t* send,
     // block until reply or timeout, we shouldn't see the ARC
     // time out, if the ARC response comes back after it
     // times out, it could pollute the result on the stack
-    if (!k_sem_take(&glcd_sem, ZJS_GLCD_TIMEOUT_TICKS)) {
+    if (k_sem_take(&glcd_sem, ZJS_GLCD_TIMEOUT_TICKS)) {
         ERR_PRINT("zjs_glcd_ipm_send_sync: FATAL ERROR, ipm timed out\n");
         return false;
     }

--- a/src/zjs_i2c.c
+++ b/src/zjs_i2c.c
@@ -28,7 +28,7 @@ static bool zjs_i2c_ipm_send_sync(zjs_ipm_message_t* send,
     }
 
     // block until reply or timeout
-    if (!k_sem_take(&i2c_sem, ZJS_I2C_TIMEOUT_TICKS)) {
+    if (k_sem_take(&i2c_sem, ZJS_I2C_TIMEOUT_TICKS)) {
         ERR_PRINT("zjs_i2c_ipm_send_sync: ipm timed out\n");
         return false;
     }


### PR DESCRIPTION
The semaphore api in the new unified kernel has a reversed return
value than previous, so we need to update all the components that
uses sempaphore, such as AIO, I2C, GroveLCD and BLE or they won't
work.

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>